### PR TITLE
initial luma.core support with luma.oled for ssd1306 and sh1106 devices

### DIFF
--- a/Documentation/behavior.md
+++ b/Documentation/behavior.md
@@ -1,15 +1,35 @@
-This file describes expected behavior of MobileMonitor. 
+This file describes expected behavior of MobileMonitor.
 
-Startup:
+### Startup:
 The program will:
 * Set all GPIO to default state
-* Look for Kismet PID
+* Initialize NeoPixels, show some output to each
+* Look for Kismet PID, if not found start kismet. If kismet does not start, output information to i2c and blink all neopixels red.
 * Attempt to connect to Kismet
+
+### Buttons
+* Hold a button to change i2c display to alternate information
+* Press a button to shut down kismet, press again to restart kismet
+* Press a button to run "I'm Home" tasks: Connect to known SSID, transfer collected data to somewhere: HTTPS, FTP, NFS, etc.  
+* Hold a button for 5 seconds to initiate system shutdown.
+
+### i2c Display - Primary information (Kismet status)
+* Websocket connection status
+* GPS status
+* Packet stream
+* uptime
+
+### i2c Display - Alternate information (System status)
+* Alternate information display can be activated by holding a button
+* CPU load, RAM usage (as %), disk usage (as %)
+* CPU temperature
+* Low voltage warning  
 
 ### NeoPixels: (order is TBD)
 Pixel 1: Websocket status
-*   RED, solid : Not connected
-*   GREEN, solid : Connected   
+* RED, solid : Not connected
+* YELLOW, solid : Authentication failure
+* GREEN, solid : Connected   
 
 Pixel 2: GPS status
 * RED, solid : No connection to GPSD
@@ -18,28 +38,28 @@ Pixel 2: GPS status
 * GREEN, solid : 3D Fix
 
 Pixel 3: SSID alert
-* RED, blink : Unencrpted SSID
+* RED, blink : Unencrypted SSID
 * YELLOW, blink : WEP SSID
 * BLUE, blink : WPA/WPA2 SSID
 * GREEN, blink : WPA3 SSID
 
 Pixel 4: AP alert
-* RED, blink : 
+* RED, blink :
 * YELLOW, blink
-* BLUE, blink :
+* BLUE, blink : New AP found
 * GREEN, blink :
 
 Pixel 5: WiFi Device alert
 * RED, blink :
-* YELLOW, blink : 
-* BLUE, blink : 
-* GREEN, blink : 
+* YELLOW, blink :
+* BLUE, blink :
+* GREEN, blink : New device found
 
-Pixel 6: Bluetooch device alert
-* RED, blink : 
-* YELLOW, blink : 
-* BLUE, blink : 
-* GREEN, blink : 
+Pixel 6: Bluetooth device alert
+* RED, blink :
+* YELLOW, blink :
+* BLUE, blink : New bluetooth device found
+* GREEN, blink :
 
 Pixel 7: Thermal alert
 * RED, blink : Over 70c

--- a/config.yaml
+++ b/config.yaml
@@ -65,7 +65,7 @@ local_gpio:
       function: new_device
 i2c_display:
   enabled: true
-  driver: adafruit_ssd1306
+  driver: luma.oled:ssd1306
   width: 128
   height: 32
   msg_disp_time: 1

--- a/mobile_monitor_rpi4.py
+++ b/mobile_monitor_rpi4.py
@@ -933,10 +933,6 @@ class i2c_controller(object):
         else:
             self.ut_str = "Not Connected"
 
-#####
-#####
-##### Start OLD CODE
-
 #Look for kismet, start if not running, etc
 def kismet_control():
     kismet_PID = NULL
@@ -962,65 +958,6 @@ def find_process(processName):
        except (psutil.NoSuchProcess, psutil.AccessDenied , psutil.ZombieProcess) :
            pass
     return listOfProcessObjects;
-
-def rgb_control(rgb_color):
-    bus = smbus.SMBus(1)
-    addr = 0x0d
-    rgb_off_reg = 0x07
-    rgb_effect_reg = 0x04
-    rgb_speed_reg = 0x05
-    rgb_color_reg = 0x06
-    Max_LED = 3
-
-    def setRGB(num, r, g, b):
-        if num >= Max_LED:
-            bus.write_byte_data(addr, 0x00, 0xff)
-            bus.write_byte_data(addr, 0x01, r&0xff)
-            bus.write_byte_data(addr, 0x02, g&0xff)
-            bus.write_byte_data(addr, 0x03, b&0xff)
-        elif num >= 0:
-            bus.write_byte_data(addr, 0x00, num&0xff)
-            bus.write_byte_data(addr, 0x01, r&0xff)
-            bus.write_byte_data(addr, 0x02, g&0xff)
-            bus.write_byte_data(addr, 0x03, b&0xff)
-
-    def setRGBEffect(effect):
-        if effect >= 0 and effect <= 4:
-            bus.write_byte_data(addr, rgb_effect_reg, effect&0xff)
-    def setRGBSpeed(speed):
-        if speed >= 1 and speed <= 3:
-            bus.write_byte_data(addr, rgb_speed_reg, speed&0xff)
-    def setRGBColor(color):
-        if color >= 0 and color <= 6:
-            bus.write_byte_data(addr, rgb_color_reg, color&0xff)
-
-    bus.write_byte_data(addr, rgb_off_reg, 0x00)
-    #time.sleep(1)
-    #0-water light, 1-breathing light, 2-marquee, 3-rainbow lights, 4-colorful lights
-    setRGBEffect(1)
-    #1-low speed, 2-medium speed (default), 3-high speed
-    setRGBSpeed(3)
-    #0-red, 1-green (default), 2-blue, 3-yellow, 4-purple, 5-cyan, 6-white
-    setRGBColor(rgb_color)
-    #Turn lED 1 RED
-    #bus.write_byte_data(addr, 0x00, 0x00)
-    #bus.write_byte_data(addr, 0x01, 0xFF)
-    #bus.write_byte_data(addr, 0x02, 0x00)
-    #bus.write_byte_data(addr, 0x03, 0x00)
-    #Trun LED 2 GREEN
-    #bus.write_byte_data(addr, 0x00, 0x01)
-    #bus.write_byte_data(addr, 0x01, 0x00)
-    #bus.write_byte_data(addr, 0x02, 0xFF)
-    #bus.write_byte_data(addr, 0x03, 0x00)
-    #Trun LED 3 BLUE
-    #bus.write_byte_data(addr, 0x00, 0x02)
-    #bus.write_byte_data(addr, 0x01, 0x00)
-    #bus.write_byte_data(addr, 0x02, 0x00)
-    #bus.write_byte_data(addr, 0x03, 0xFF)
-
-#####
-#####
-##### End OLD CODE
 
 if __name__ == "__main__":
     # load config


### PR DESCRIPTION
- sh1106 is untested (let me know if there is any problem)
- very minimal testing on luma.oled:ssd1306 - of note does not scale like adafruit_ssd1306, ie configing 128x64 screen at 128x32 causes error